### PR TITLE
Errors return error log to client resolve #25

### DIFF
--- a/backend/src/dao.py
+++ b/backend/src/dao.py
@@ -26,7 +26,7 @@ class DAO:
                 )
             except psycopg2.Error as e:
                 print("Error executing SQL query:", e)
-                raise HTTPException(status_code=500, detail="Database error")
+                raise HTTPException(status_code=500, detail=f"Database error: {e}")
 
             # Unpack the tuples into constructor
             return [cls(*row) for row in curs.fetchall()]
@@ -47,7 +47,7 @@ class DAO:
                 )
             except psycopg2.Error as e:
                 print("Error executing SQL query:", e)
-                raise HTTPException(status_code=500, detail="Database error")
+                raise HTTPException(status_code=500, detail=f"Database error: {e}")
 
             # Unpack the tuple into constructor
             return cls(*curs.fetchone())
@@ -80,7 +80,7 @@ class DAO:
                 )
             except psycopg2.Error as e:
                 print("Error executing SQL query:", e)
-                raise HTTPException(status_code=500, detail="Database error")
+                raise HTTPException(status_code=500, detail=f"Database error: {e}")
 
             # Unpack the tuple into constructor
 
@@ -127,7 +127,7 @@ class Node(DAO):
                 return cls(nid, ntype, nlatitude, nlongitude, ndescription)
             except psycopg2.Error as e:
                 print("Error executing SQL query:", e)
-                raise HTTPException(status_code=500, detail="Database error")
+                raise HTTPException(status_code=500, detail=f"Database error: {e}")
 
 
 @dataclass
@@ -161,7 +161,7 @@ class TimestampIndex(DAO):
                 return tid
             except psycopg2.Error as e:
                 print("Error executing SQL query:", e)
-                raise HTTPException(status_code=500, detail="Database error")
+                raise HTTPException(status_code=500, detail=f"Database error: {e}")
 
 
 @dataclass
@@ -226,7 +226,7 @@ class AudioFile(DAO):
                 )
             except psycopg2.Error as e:
                 print("Error executing SQL query:", e)
-                raise HTTPException(status_code=500, detail="Database error")
+                raise HTTPException(status_code=500, detail=f"Database error: {e}")
 
             # Not pulling the audio data.
             return [cls(row[0], row[1], None) for row in curs.fetchall()]
@@ -253,7 +253,7 @@ class AudioFile(DAO):
                 return str(afid)
             except psycopg2.Error as e:
                 print("Error executing SQL query:", e)
-                raise HTTPException(status_code=500, detail="Database error")
+                raise HTTPException(status_code=500, detail=f"Database error: {e}")
 
 class Dashboard:
     """Collection of queries for dashboard endpoints"""
@@ -290,7 +290,7 @@ class Dashboard:
                 }
             except psycopg2.Error as e:
                 print("Error executing SQL query:", e)
-                raise HTTPException(status_code=500, detail="Database error")
+                raise HTTPException(status_code=500, detail=f"Database error: {e}")
 
 
     
@@ -321,7 +321,7 @@ class Dashboard:
                 
             except psycopg2.Error as e:
                 print("Error executing SQL query:", e)
-                raise HTTPException(status_code=500, detail="Database error")
+                raise HTTPException(status_code=500, detail=f"Database error: {e}")
        
         
     @staticmethod
@@ -392,6 +392,6 @@ class Dashboard:
 
             except psycopg2.Error as e:
                 print("Error executing SQL query:", e)
-                raise HTTPException(status_code=500, detail="Database error")
+                raise HTTPException(status_code=500, detail=f"Database error: {e}")
 
 

--- a/backend/src/dao.py
+++ b/backend/src/dao.py
@@ -26,7 +26,7 @@ class DAO:
                 )
             except psycopg2.Error as e:
                 print("Error executing SQL query:", e)
-                raise HTTPException(status_code=500, detail=f"Database error: {e}")
+                raise HTTPException(status_code=500, detail=f"Database error: {e.pgcode}")
 
             # Unpack the tuples into constructor
             return [cls(*row) for row in curs.fetchall()]
@@ -47,7 +47,7 @@ class DAO:
                 )
             except psycopg2.Error as e:
                 print("Error executing SQL query:", e)
-                raise HTTPException(status_code=500, detail=f"Database error: {e}")
+                raise HTTPException(status_code=500, detail=f"Database error: {e.pgcode}")
 
             # Unpack the tuple into constructor
             return cls(*curs.fetchone())
@@ -80,7 +80,7 @@ class DAO:
                 )
             except psycopg2.Error as e:
                 print("Error executing SQL query:", e)
-                raise HTTPException(status_code=500, detail=f"Database error: {e}")
+                raise HTTPException(status_code=500, detail=f"Database error: {e.pgcode}")
 
             # Unpack the tuple into constructor
 
@@ -127,7 +127,7 @@ class Node(DAO):
                 return cls(nid, ntype, nlatitude, nlongitude, ndescription)
             except psycopg2.Error as e:
                 print("Error executing SQL query:", e)
-                raise HTTPException(status_code=500, detail=f"Database error: {e}")
+                raise HTTPException(status_code=500, detail=f"Database error: {e.pgcode}")
 
 
 @dataclass
@@ -161,7 +161,7 @@ class TimestampIndex(DAO):
                 return tid
             except psycopg2.Error as e:
                 print("Error executing SQL query:", e)
-                raise HTTPException(status_code=500, detail=f"Database error: {e}")
+                raise HTTPException(status_code=500, detail=f"Database error: {e.pgcode}")
 
 
 @dataclass
@@ -226,7 +226,7 @@ class AudioFile(DAO):
                 )
             except psycopg2.Error as e:
                 print("Error executing SQL query:", e)
-                raise HTTPException(status_code=500, detail=f"Database error: {e}")
+                raise HTTPException(status_code=500, detail=f"Database error: {e.pgcode}")
 
             # Not pulling the audio data.
             return [cls(row[0], row[1], None) for row in curs.fetchall()]
@@ -253,7 +253,7 @@ class AudioFile(DAO):
                 return str(afid)
             except psycopg2.Error as e:
                 print("Error executing SQL query:", e)
-                raise HTTPException(status_code=500, detail=f"Database error: {e}")
+                raise HTTPException(status_code=500, detail=f"Database error: {e.pgcode}")
 
 class Dashboard:
     """Collection of queries for dashboard endpoints"""
@@ -290,7 +290,7 @@ class Dashboard:
                 }
             except psycopg2.Error as e:
                 print("Error executing SQL query:", e)
-                raise HTTPException(status_code=500, detail=f"Database error: {e}")
+                raise HTTPException(status_code=500, detail=f"Database error: {e.pgcode}")
 
 
     
@@ -321,7 +321,7 @@ class Dashboard:
                 
             except psycopg2.Error as e:
                 print("Error executing SQL query:", e)
-                raise HTTPException(status_code=500, detail=f"Database error: {e}")
+                raise HTTPException(status_code=500, detail=f"Database error: {e.pgcode}")
        
         
     @staticmethod
@@ -392,6 +392,6 @@ class Dashboard:
 
             except psycopg2.Error as e:
                 print("Error executing SQL query:", e)
-                raise HTTPException(status_code=500, detail=f"Database error: {e}")
+                raise HTTPException(status_code=500, detail=f"Database error: {e.pgcode}")
 
 

--- a/backend/src/dao.py
+++ b/backend/src/dao.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from fastapi import HTTPException
 from time import time
+from dbutil import default_HTTP_exception
 
 from itertools import starmap
 
@@ -26,7 +27,7 @@ class DAO:
                 )
             except psycopg2.Error as e:
                 print("Error executing SQL query:", e)
-                raise HTTPException(status_code=500, detail=f"Database error: {e.pgcode}")
+                raise default_HTTP_exception(e.pgcode, "get all query")
 
             # Unpack the tuples into constructor
             return [cls(*row) for row in curs.fetchall()]
@@ -47,7 +48,7 @@ class DAO:
                 )
             except psycopg2.Error as e:
                 print("Error executing SQL query:", e)
-                raise HTTPException(status_code=500, detail=f"Database error: {e.pgcode}")
+                raise default_HTTP_exception(e.pgcode, "get query")
 
             # Unpack the tuple into constructor
             return cls(*curs.fetchone())
@@ -80,7 +81,7 @@ class DAO:
                 )
             except psycopg2.Error as e:
                 print("Error executing SQL query:", e)
-                raise HTTPException(status_code=500, detail=f"Database error: {e.pgcode}")
+                raise default_HTTP_exception(e.pgcode, "delete query")
 
             # Unpack the tuple into constructor
 
@@ -127,7 +128,7 @@ class Node(DAO):
                 return cls(nid, ntype, nlatitude, nlongitude, ndescription)
             except psycopg2.Error as e:
                 print("Error executing SQL query:", e)
-                raise HTTPException(status_code=500, detail=f"Database error: {e.pgcode}")
+                raise default_HTTP_exception(e.pgcode, "insert node query")
 
 
 @dataclass
@@ -161,7 +162,7 @@ class TimestampIndex(DAO):
                 return tid
             except psycopg2.Error as e:
                 print("Error executing SQL query:", e)
-                raise HTTPException(status_code=500, detail=f"Database error: {e.pgcode}")
+                raise default_HTTP_exception(e.pgcode, "insert timestamp query")
 
 
 @dataclass
@@ -226,7 +227,7 @@ class AudioFile(DAO):
                 )
             except psycopg2.Error as e:
                 print("Error executing SQL query:", e)
-                raise HTTPException(status_code=500, detail=f"Database error: {e.pgcode}")
+                raise default_HTTP_exception(e.pgcode, "get audio file query")
 
             # Not pulling the audio data.
             return [cls(row[0], row[1], None) for row in curs.fetchall()]
@@ -253,7 +254,7 @@ class AudioFile(DAO):
                 return str(afid)
             except psycopg2.Error as e:
                 print("Error executing SQL query:", e)
-                raise HTTPException(status_code=500, detail=f"Database error: {e.pgcode}")
+                raise default_HTTP_exception(e.pgcode, "insert audio file query")
 
 class Dashboard:
     """Collection of queries for dashboard endpoints"""
@@ -290,7 +291,7 @@ class Dashboard:
                 }
             except psycopg2.Error as e:
                 print("Error executing SQL query:", e)
-                raise HTTPException(status_code=500, detail=f"Database error: {e.pgcode}")
+                raise default_HTTP_exception(e.pgcode, "dashboard species weekly summary query")
 
 
     
@@ -321,7 +322,7 @@ class Dashboard:
                 
             except psycopg2.Error as e:
                 print("Error executing SQL query:", e)
-                raise HTTPException(status_code=500, detail=f"Database error: {e.pgcode}")
+                raise default_HTTP_exception(e.pgcode, "dashboard node health check query")
        
         
     @staticmethod
@@ -392,6 +393,6 @@ class Dashboard:
 
             except psycopg2.Error as e:
                 print("Error executing SQL query:", e)
-                raise HTTPException(status_code=500, detail=f"Database error: {e.pgcode}")
+                raise default_HTTP_exception(e.pgcode, "dashboard recent reports query")
 
 

--- a/backend/src/dbutil.py
+++ b/backend/src/dbutil.py
@@ -80,8 +80,12 @@ def get_db_connection():
     """
     connection = get_database_connection()
     if connection is None:
-        raise HTTPException(status_code=500, detail="Database connection error")
+        raise HTTPException(status_code=500, detail="Database connection error while making connection")
     try:
         yield connection
     finally:
         connection.close()
+
+
+def default_HTTP_exception(code: str, additional_info: str) -> HTTPException.HTTPException:
+    return HTTPException(status_code=500, detail=f"Database error {code}: {psycopg2.errors.lookup(code)}\n While doing " + additional_info)

--- a/backend/src/dbutil.py
+++ b/backend/src/dbutil.py
@@ -33,7 +33,7 @@ def get_connection_from_environment():
         )
         return connection
     except psycopg2.Error as e:
-        print("Error Creating Connection Object to database:", e)
+        print("Error Creating Connection Object to database:", e.pgerror)
         return None
 
 
@@ -52,7 +52,7 @@ def get_connection_from_development_config():
             connection = psycopg2.connect(**db_config)
             return connection
         except psycopg2.Error as e:
-            print("Error connecting to database:", e)
+            print("Error connecting to database:", e.pgerror)
             return None
 
 


### PR DESCRIPTION
Added this so that when a database error happens it shows up on the client and not just the server logs. We should check that the psycopg2 errors never actually show any data, though, because that might be a security issue.